### PR TITLE
fix(flake/install): now working on arm64

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           pname = "c_formatter_42";
           version = "1.0";
           src = src_patched;
-          buildInputs = [pkgs.clang-tools ];
+          buildInputs = [pkgs.clang-tools];
           pyproject = true;
           build-system = [ pkgs.python311Packages.setuptools ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
             cp $src/c_formatter_42/formatters/*.py $out/c_formatter_42/formatters
             ln -s ${clang-format-wrapper} $out/c_formatter_42/data/clang-format-linux
             ln -s ${clang-format-wrapper} $out/c_formatter_42/data/clang-format-darwin
+            ln -s ${clang-format-wrapper} $out/c_formatter_42/data/clang-format-darwin-arm64
           '';
         };
         c_formatter_42_drv = pkgs.python311Packages.buildPythonApplication {


### PR DESCRIPTION
- 🛠️ Added a new symlink for **`clang-format-wrapper`** as **`clang-format-darwin-arm64`** inside the `c_formatter_42/data` directory.  
- 🍏 This patch ensures better compatibility and smoother support for **Apple Silicon (arm64) Macs** when using the flake build for **c_formatter_42**.